### PR TITLE
Install SDK during CI/CD build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,16 @@ skip_commits:
 skip_tags: true
 pull_requests:
   do_not_increment_build_number: true
+environment:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+install:
+- cmd: curl -sSLO https://dot.net/v1/dotnet-install.ps1
+- ps: if ($isWindows) { ./dotnet-install.ps1 --version 2.1.500 }
+- sh: curl -sSLO https://dot.net/v1/dotnet-install.sh
+- sh: chmod +x dotnet-install.sh
+- sh: ./dotnet-install.sh --version 2.1.500
+- sh: export PATH="$HOME/.dotnet:$PATH"
 build_script:
 - ps: >-
     $id = $env:APPVEYOR_REPO_COMMIT_TIMESTAMP -replace '([-:]|\.0+Z)', ''


### PR DESCRIPTION
This PR is to avoid the problem that occurred with building ab08a3ba9852059246df7a184d29c4e6d843b8de on Ubuntu where the required SDK was missing.
