### PR TITLE
Add support for async streams

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,15 @@ install:
 - cmd: dotnet-runtime-2.0.9-win-x64.exe /quiet /norestart
 - cmd: curl -sSLO https://download.visualstudio.microsoft.com/download/pr/d046f80d-8ad4-4bb9-8db6-8510105de979/07319c666f9951e15c607aed260ab12d/dotnet-runtime-2.1.13-win-x64.exe
 - cmd: dotnet-runtime-2.1.13-win-x64.exe /quiet /norestart
+- cmd: curl -sSLO https://download.visualstudio.microsoft.com/download/pr/a803822b-178b-4d21-bb7c-aaa1d209c341/e77c5ca1d0ea9963346655e2ec2733f2/dotnet-runtime-2.2.7-win-x64.exe
+- cmd: dotnet-runtime-2.2.7-win-x64.exe /quiet /norestart
 - cmd: curl -sSLO https://download.visualstudio.microsoft.com/download/pr/53f250a1-318f-4350-8bda-3c6e49f40e76/e8cbbd98b08edd6222125268166cfc43/dotnet-sdk-3.0.100-win-x64.exe
 - cmd: dotnet-sdk-3.0.100-win-x64.exe /quiet /norestart
 - sh: curl -sSLO https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
-- sh: ./dotnet-install.sh --version 2.0.9 --runtime dotnet
-- sh: ./dotnet-install.sh --version 2.1.13 --runtime dotnet
+- sh: ./dotnet-install.sh --version 2.0.9   --runtime dotnet
+- sh: ./dotnet-install.sh --version 2.1.13  --runtime dotnet
+- sh: ./dotnet-install.sh --version 2.2.7   --runtime dotnet
 - sh: ./dotnet-install.sh --version 3.0.100
 - sh: export PATH="$HOME/.dotnet:$PATH"
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 version: '{build}'
-image:
-  - Visual Studio 2019
-  - Ubuntu
+image: Visual Studio 2019
 skip_commits:
   files:
     - '*.md'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: '{build}'
-image: Visual Studio 2019
+image:
+  - Visual Studio 2019
+  - Ubuntu
 skip_commits:
   files:
     - '*.md'
@@ -11,8 +13,18 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
-- curl -O https://dot.net/v1/dotnet-install.ps1
-- ps: ./dotnet-install.ps1 -Version ((type ./global.json | ConvertFrom-Json).sdk.version)
+- cmd: curl -sSLO https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x64.exe
+- cmd: dotnet-runtime-2.0.9-win-x64.exe /quiet /norestart
+- cmd: curl -sSLO https://download.visualstudio.microsoft.com/download/pr/d046f80d-8ad4-4bb9-8db6-8510105de979/07319c666f9951e15c607aed260ab12d/dotnet-runtime-2.1.13-win-x64.exe
+- cmd: dotnet-runtime-2.1.13-win-x64.exe /quiet /norestart
+- cmd: curl -sSLO https://download.visualstudio.microsoft.com/download/pr/53f250a1-318f-4350-8bda-3c6e49f40e76/e8cbbd98b08edd6222125268166cfc43/dotnet-sdk-3.0.100-win-x64.exe
+- cmd: dotnet-sdk-3.0.100-win-x64.exe /quiet /norestart
+- sh: curl -sSLO https://dot.net/v1/dotnet-install.sh
+- sh: chmod +x dotnet-install.sh
+- sh: ./dotnet-install.sh --version 2.0.9 --runtime dotnet
+- sh: ./dotnet-install.sh --version 2.1.13 --runtime dotnet
+- sh: ./dotnet-install.sh --version 3.0.100
+- sh: export PATH="$HOME/.dotnet:$PATH"
 build_script:
 - ps: >-
     $id = $env:APPVEYOR_REPO_COMMIT_TIMESTAMP -replace '([-:]|\.0+Z)', ''

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
   - Ubuntu
 skip_commits:
   files:
@@ -13,12 +13,8 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
-- cmd: curl -sSLO https://dot.net/v1/dotnet-install.ps1
-- ps: if ($isWindows) { ./dotnet-install.ps1 --version 2.1.500 }
-- sh: curl -sSLO https://dot.net/v1/dotnet-install.sh
-- sh: chmod +x dotnet-install.sh
-- sh: ./dotnet-install.sh --version 2.1.500
-- sh: export PATH="$HOME/.dotnet:$PATH"
+- curl -O https://dot.net/v1/dotnet-install.ps1
+- ps: ./dotnet-install.ps1 -Version ((type ./global.json | ConvertFrom-Json).sdk.version)
 build_script:
 - ps: >-
     $id = $env:APPVEYOR_REPO_COMMIT_TIMESTAMP -replace '([-:]|\.0+Z)', ''

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview7-012821"
+    "version": "3.0.100"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.1.500"
+    "version": "3.0.100-preview7-012821"
   }
 }

--- a/src/Async.cs
+++ b/src/Async.cs
@@ -1,0 +1,114 @@
+#region Copyright 2019 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+#if !NO_ASYNC_STREAM
+
+namespace Dsv
+{
+    using System;
+    using System.Collections.Generic;
+
+    static partial class Parser
+    {
+        public static IAsyncEnumerable<(T Header, TextRow Row)>
+            ParseCsv<T>(this IAsyncEnumerable<string> lines,
+                        Func<TextRow, T> headSelector) =>
+            lines.ParseDsv(Format.Csv, headSelector, ValueTuple.Create);
+
+        public static IAsyncEnumerable<TRow> ParseCsv<THead, TRow>(this IAsyncEnumerable<string> lines,
+            Func<TextRow, THead> headSelector,
+            Func<THead, TextRow, TRow> rowSelector) =>
+            lines.ParseDsv(Format.Csv, headSelector, rowSelector);
+
+        public static IAsyncEnumerable<(T Header, TextRow Row)>
+            ParseDsv<T>(this IAsyncEnumerable<string> lines,
+                        Format format,
+                        Func<TextRow, T> headSelector) =>
+            lines.ParseDsv(format, _ => false, headSelector);
+
+        public static IAsyncEnumerable<(T Header, TextRow Row)>
+            ParseDsv<T>(this IAsyncEnumerable<string> lines,
+                        Format format,
+                        Func<string, bool> lineFilter,
+                        Func<TextRow, T> headSelector) =>
+            lines.ParseDsv(format, lineFilter, headSelector, ValueTuple.Create);
+
+        public static IAsyncEnumerable<TRow> ParseDsv<THead, TRow>(this IAsyncEnumerable<string> lines,
+            Format format,
+            Func<TextRow, THead> headSelector,
+            Func<THead, TextRow, TRow> rowSelector) =>
+            lines.ParseDsv(format, _ => false, headSelector, rowSelector);
+
+        public static IAsyncEnumerable<TRow> ParseDsv<THead, TRow>(this IAsyncEnumerable<string> lines,
+            Format format,
+            Func<string, bool> lineFilter,
+            Func<TextRow, THead> headSelector,
+            Func<THead, TextRow, TRow> rowSelector)
+        {
+            if (lines == null) throw new ArgumentNullException(nameof(lines));
+            if (format == null) throw new ArgumentNullException(nameof(format));
+            if (lineFilter == null) throw new ArgumentNullException(nameof(lineFilter));
+            if (headSelector == null) throw new ArgumentNullException(nameof(headSelector));
+            if (rowSelector == null) throw new ArgumentNullException(nameof(rowSelector));
+
+            return _(); async IAsyncEnumerable<TRow> _()
+            {
+                // TODO review CancellationToken.None
+                // TODO review await configuration
+
+                await using var row = lines.ParseDsv(format, lineFilter).GetAsyncEnumerator(System.Threading.CancellationToken.None);
+
+                if (!(await row.MoveNextAsync()))
+                    yield break;
+
+                var head = headSelector(row.Current);
+
+                while (await row.MoveNextAsync())
+                    yield return rowSelector(head, row.Current);
+            }
+        }
+
+        public static IAsyncEnumerable<TextRow> ParseCsv(this IAsyncEnumerable<string> lines) =>
+            lines.ParseDsv(Format.Csv);
+
+        public static IAsyncEnumerable<TextRow> ParseCsv(this IAsyncEnumerable<string> lines, Func<string, bool> lineFilter) =>
+            lines.ParseDsv(Format.Csv, lineFilter);
+
+        public static IAsyncEnumerable<TextRow> ParseDsv(this IAsyncEnumerable<string> lines,
+            Format format) =>
+            lines.ParseDsv(format, (string _) => false);
+
+        public static async IAsyncEnumerable<TextRow> ParseDsv(this IAsyncEnumerable<string> lines,
+            Format format, Func<string, bool> lineFilter)
+        {
+            var (onLine, onEoi) = Create(format, lineFilter);
+
+            // TODO review CancellationToken.None
+            // TODO review await configuration
+
+            await foreach (var line in lines)
+            {
+                if (onLine(line) is TextRow row)
+                    yield return row;
+            }
+
+            if (onEoi() is Exception e)
+                throw e;
+        }
+    }
+}
+
+#endif // !NO_ASYNC_STREAM

--- a/src/DelegatingAsyncEnumerable.cs
+++ b/src/DelegatingAsyncEnumerable.cs
@@ -1,0 +1,37 @@
+#region Copyright 2019 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+#if !NO_ASYNC_STREAM
+
+namespace Dsv
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    sealed class DelegatingAsyncEnumerable<T> : IAsyncEnumerable<T>
+    {
+        readonly Func<CancellationToken, IAsyncEnumerator<T>> _delegatee;
+
+        public DelegatingAsyncEnumerable(Func<CancellationToken, IAsyncEnumerator<T>> delegatee) =>
+            _delegatee = delegatee ?? throw new ArgumentNullException(nameof(delegatee));
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+            _delegatee(cancellationToken);
+    }
+}
+
+#endif // !NO_ASYNC_STREAM

--- a/src/Dsv.csproj
+++ b/src/Dsv.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
-    <LangVersion>7.1</LangVersion>
     <VersionPrefix>1.4.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
     <Copyright>Copyright © 2017 Atif Aziz</Copyright>
     <Description>DSV (Delimiter-Separated Values) Parsing for .NET</Description>
     <Authors>Atif Aziz</Authors>
@@ -14,6 +14,10 @@
     <PackageTags>dsv csv tsv text</PackageTags>
     <PackageLicenseFile>COPYING.txt</PackageLicenseFile>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework) == 'netstandard2.1'">
+    <DefineConstants>$(DefineConstants);ASYNC_ENUM</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Dsv.csproj
+++ b/src/Dsv.csproj
@@ -16,10 +16,6 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework) == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);ASYNC_ENUM</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\</OutputPath>
   </PropertyGroup>
@@ -27,6 +23,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\bin\Release\</OutputPath>
   </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework) == 'netstandard1.0'">
+    <DefineConstants>$(DefineConstants);NO_ASYNC_STREAM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Interactive.Async">
+      <Version>4.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="'$(TargetFramework)'=='netstandard1.0'" />

--- a/src/Parser.cs
+++ b/src/Parser.cs
@@ -180,6 +180,68 @@ namespace Dsv
             }
         }
 
+        #if ASYNC_ENUM
+
+        public static IAsyncEnumerable<(T Header, TextRow Row)>
+            ParseCsv<T>(this IAsyncEnumerable<string> lines,
+                        Func<TextRow, T> headSelector) =>
+            lines.ParseDsv(Format.Csv, headSelector, ValueTuple.Create);
+
+        public static IAsyncEnumerable<TRow> ParseCsv<THead, TRow>(this IAsyncEnumerable<string> lines,
+            Func<TextRow, THead> headSelector,
+            Func<THead, TextRow, TRow> rowSelector) =>
+            lines.ParseDsv(Format.Csv, headSelector, rowSelector);
+
+        public static IAsyncEnumerable<(T Header, TextRow Row)>
+            ParseDsv<T>(this IAsyncEnumerable<string> lines,
+                        Format format,
+                        Func<TextRow, T> headSelector) =>
+            lines.ParseDsv(format, _ => false, headSelector);
+
+        public static IAsyncEnumerable<(T Header, TextRow Row)>
+            ParseDsv<T>(this IAsyncEnumerable<string> lines,
+                        Format format,
+                        Func<string, bool> lineFilter,
+                        Func<TextRow, T> headSelector) =>
+            lines.ParseDsv(format, lineFilter, headSelector, ValueTuple.Create);
+
+        public static IAsyncEnumerable<TRow> ParseDsv<THead, TRow>(this IAsyncEnumerable<string> lines,
+            Format format,
+            Func<TextRow, THead> headSelector,
+            Func<THead, TextRow, TRow> rowSelector) =>
+            lines.ParseDsv(format, _ => false, headSelector, rowSelector);
+
+        public static IAsyncEnumerable<TRow> ParseDsv<THead, TRow>(this IAsyncEnumerable<string> lines,
+            Format format,
+            Func<string, bool> lineFilter,
+            Func<TextRow, THead> headSelector,
+            Func<THead, TextRow, TRow> rowSelector)
+        {
+            if (lines == null) throw new ArgumentNullException(nameof(lines));
+            if (format == null) throw new ArgumentNullException(nameof(format));
+            if (lineFilter == null) throw new ArgumentNullException(nameof(lineFilter));
+            if (headSelector == null) throw new ArgumentNullException(nameof(headSelector));
+            if (rowSelector == null) throw new ArgumentNullException(nameof(rowSelector));
+
+            return _(); async IAsyncEnumerable<TRow> _()
+            {
+                // TODO review CancellationToken.None
+                // TODO review await configuration
+
+                await using var row = lines.ParseDsv(format, lineFilter).GetAsyncEnumerator(System.Threading.CancellationToken.None);
+
+                if (!(await row.MoveNextAsync()))
+                    yield break;
+
+                var head = headSelector(row.Current);
+
+                while (await row.MoveNextAsync())
+                    yield return rowSelector(head, row.Current);
+            }
+        }
+
+        #endif // ASYNC_ENUM
+
         /// <summary>
         /// Parses CSV data from a sequence of lines, allowing quoted
         /// fields and using two quotes to escape quote within a quoted
@@ -191,6 +253,16 @@ namespace Dsv
 
         public static IEnumerable<TextRow> ParseCsv(this IEnumerable<string> lines, Func<string, bool> lineFilter) =>
             lines.ParseDsv(Format.Csv, lineFilter);
+
+        #if ASYNC_ENUM
+
+        public static IAsyncEnumerable<TextRow> ParseCsv(this IAsyncEnumerable<string> lines) =>
+            lines.ParseDsv(Format.Csv);
+
+        public static IAsyncEnumerable<TextRow> ParseCsv(this IAsyncEnumerable<string> lines, Func<string, bool> lineFilter) =>
+            lines.ParseDsv(Format.Csv, lineFilter);
+
+        #endif // ASYNC_ENUM
 
         /// <summary>
         /// Parses delimiter-separated values, like CSV, given a sequence
@@ -215,6 +287,32 @@ namespace Dsv
             if (onEoi() is Exception e)
                 throw e;
         }
+
+        #if ASYNC_ENUM
+
+        public static IAsyncEnumerable<TextRow> ParseDsv(this IAsyncEnumerable<string> lines,
+            Format format) =>
+            lines.ParseDsv(format, (string _) => false);
+
+        public static async IAsyncEnumerable<TextRow> ParseDsv(this IAsyncEnumerable<string> lines,
+            Format format, Func<string, bool> lineFilter)
+        {
+            var (onLine, onEoi) = Create(format, lineFilter);
+
+            // TODO review CancellationToken.None
+            // TODO review await configuration
+
+            await foreach (var line in lines)
+            {
+                if (onLine(line) is TextRow row)
+                    yield return row;
+            }
+
+            if (onEoi() is Exception e)
+                throw e;
+        }
+
+        #endif // ASYNC_ENUM
 
         static (Func<string, TextRow?> OnLine, Func<Exception> OnEoi)
             Create(Format format, Func<string, bool> lineFilter)

--- a/src/Parser.cs
+++ b/src/Parser.cs
@@ -180,7 +180,7 @@ namespace Dsv
             }
         }
 
-        #if ASYNC_ENUM
+        #if !NO_ASYNC_STREAM
 
         public static IAsyncEnumerable<(T Header, TextRow Row)>
             ParseCsv<T>(this IAsyncEnumerable<string> lines,
@@ -240,7 +240,7 @@ namespace Dsv
             }
         }
 
-        #endif // ASYNC_ENUM
+        #endif // !NO_ASYNC_STREAM
 
         /// <summary>
         /// Parses CSV data from a sequence of lines, allowing quoted
@@ -254,7 +254,7 @@ namespace Dsv
         public static IEnumerable<TextRow> ParseCsv(this IEnumerable<string> lines, Func<string, bool> lineFilter) =>
             lines.ParseDsv(Format.Csv, lineFilter);
 
-        #if ASYNC_ENUM
+        #if !NO_ASYNC_STREAM
 
         public static IAsyncEnumerable<TextRow> ParseCsv(this IAsyncEnumerable<string> lines) =>
             lines.ParseDsv(Format.Csv);
@@ -262,7 +262,7 @@ namespace Dsv
         public static IAsyncEnumerable<TextRow> ParseCsv(this IAsyncEnumerable<string> lines, Func<string, bool> lineFilter) =>
             lines.ParseDsv(Format.Csv, lineFilter);
 
-        #endif // ASYNC_ENUM
+        #endif // NO_ASYNC_STREAM
 
         /// <summary>
         /// Parses delimiter-separated values, like CSV, given a sequence
@@ -288,7 +288,7 @@ namespace Dsv
                 throw e;
         }
 
-        #if ASYNC_ENUM
+        #if !NO_ASYNC_STREAM
 
         public static IAsyncEnumerable<TextRow> ParseDsv(this IAsyncEnumerable<string> lines,
             Format format) =>
@@ -312,7 +312,7 @@ namespace Dsv
                 throw e;
         }
 
-        #endif // ASYNC_ENUM
+        #endif // !NO_ASYNC_STREAM
 
         static (Func<string, TextRow?> OnLine, Func<Exception> OnEoi)
             Create(Format format, Func<string, bool> lineFilter)

--- a/tests/Dsv.Tests.csproj
+++ b/tests/Dsv.Tests.csproj
@@ -1,9 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
-    <LangVersion>7.1</LangVersion>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
     <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.0'">
+    <DefineConstants>$(DefineConstants);ASYNC_ENUM</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Dsv.Tests.csproj
+++ b/tests/Dsv.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Dsv.Tests.csproj
+++ b/tests/Dsv.Tests.csproj
@@ -6,10 +6,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.0'">
-    <DefineConstants>$(DefineConstants);ASYNC_ENUM</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Remove="Tests.md" />
   </ItemGroup>
@@ -26,6 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="morelinq" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
     <PackageReference Include="System.Reactive" Version="4.1.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Dsv.Tests.csproj
+++ b/tests/Dsv.Tests.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\src\DelegatingAsyncEnumerable.cs" Link="DelegatingAsyncEnumerable.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Tests.md" />
   </ItemGroup>
 
@@ -22,7 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="morelinq" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
+    <PackageReference Include="System.Interactive.Async" Version="4.0.0" Condition="'$(TargetFramework)'!='netcoreapp3.0'" />
     <PackageReference Include="System.Reactive" Version="4.1.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Dsv.Tests.csproj
+++ b/tests/Dsv.Tests.csproj
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.5.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="morelinq" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Interactive.Async" Version="4.0.0" />

--- a/tests/Extensions.cs
+++ b/tests/Extensions.cs
@@ -47,7 +47,7 @@ namespace Dsv.Tests
             return type.Assembly.GetManifestResourceStream(type, resourceName);
         }
 
-        #if ASYNC_ENUM
+        #if !NO_ASYNC_STREAM
 
         public static IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> source)
         {
@@ -83,6 +83,6 @@ namespace Dsv.Tests
             }
         }
 
-        #endif // ASYNC_ENUM
+        #endif // !NO_ASYNC_STREAM
     }
 }

--- a/tests/Extensions.cs
+++ b/tests/Extensions.cs
@@ -46,5 +46,43 @@ namespace Dsv.Tests
             if (type == null) throw new ArgumentNullException(nameof(type));
             return type.Assembly.GetManifestResourceStream(type, resourceName);
         }
+
+        #if ASYNC_ENUM
+
+        public static IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            #pragma warning disable 1998 // This async method lacks 'await' operators and will run synchronously
+
+            return _(); async IAsyncEnumerable<T> _()
+            {
+                foreach (var item in source)
+                    yield return item;
+            }
+
+            #pragma warning restore 1998
+        }
+
+        public static IEnumerable<T> ToEnumerable<T>(this IAsyncEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return _(); IEnumerable<T> _()
+            {
+                var item = source.GetAsyncEnumerator(System.Threading.CancellationToken.None);
+                try
+                {
+                    while (item.MoveNextAsync().GetAwaiter().GetResult())
+                        yield return item.Current;
+                }
+                finally
+                {
+                    item.DisposeAsync().GetAwaiter().GetResult();
+                }
+            }
+        }
+
+        #endif // ASYNC_ENUM
     }
 }

--- a/tests/ParserTests.cs
+++ b/tests/ParserTests.cs
@@ -107,7 +107,7 @@ namespace Dsv.Tests
             }
         }
 
-        #if ASYNC_ENUM
+        #if !NO_ASYNC_STREAM
 
         public class AsyncEnumerableSource
         {
@@ -191,7 +191,7 @@ namespace Dsv.Tests
             }
         }
 
-        #endif // ASYNC_ENUM
+        #endif // !NO_ASYNC_STREAM
 
         public class ObservableSource
         {
@@ -313,7 +313,7 @@ namespace Dsv.Tests
             ParseDsv(delimiter, quote, escape, newline, skipBlanks, rows, errorType, errorMessage,
                      lines.ParseDsv);
 
-        #if ASYNC_ENUM
+        #if !NO_ASYNC_STREAM
 
         [Theory]
         [MemberData(nameof(GetData))]
@@ -327,7 +327,7 @@ namespace Dsv.Tests
                                      .ParseDsv(f, rf)
                                      .ToEnumerable());
 
-        #endif // ASYNC_ENUM
+        #endif // !NO_ASYNC_STREAM
 
         [Theory]
         [MemberData(nameof(GetData))]

--- a/tests/ParserTests.cs
+++ b/tests/ParserTests.cs
@@ -91,10 +91,10 @@ namespace Dsv.Tests
             [Fact]
             public void ParseIsLazy()
             {
-                IEnumerable<string> Lines()
+                static IEnumerable<string> Lines()
                 {
                     throw new InvalidOperationException();
-                    #pragma warning disable 162
+                    #pragma warning disable 162 // Unreachable code detected
                     yield return null;
                     #pragma warning restore 162
                 }
@@ -106,6 +106,92 @@ namespace Dsv.Tests
                     rowSelector : delegate { throw new NotImplementedException(); });
             }
         }
+
+        #if ASYNC_ENUM
+
+        public class AsyncEnumerableSource
+        {
+            [Fact]
+            public void ParseWithNullLinesThrows()
+            {
+                var e = Assert.Throws<ArgumentNullException>(() =>
+                    Parser.ParseDsv<object, object>(
+                        (IAsyncEnumerable<string>) null, Format.Csv,
+                        lineFilter  : delegate { throw new NotImplementedException(); },
+                        headSelector: delegate { throw new NotImplementedException(); },
+                        rowSelector : delegate { throw new NotImplementedException(); }));
+                Assert.Equal("lines", e.ParamName);
+            }
+
+            [Fact]
+            public void ParseWithNullFormatThrows()
+            {
+                var e = Assert.Throws<ArgumentNullException>(() =>
+                    new string[0].ParseDsv<object, object>(
+                        format: null,
+                        lineFilter  : delegate { throw new NotImplementedException(); },
+                        headSelector: delegate { throw new NotImplementedException(); },
+                        rowSelector : delegate { throw new NotImplementedException(); }));
+                Assert.Equal("format", e.ParamName);
+            }
+
+            [Fact]
+            public void ParseWithNullRowFilterThrows()
+            {
+                var e = Assert.Throws<ArgumentNullException>(() =>
+                    new string[0].ParseDsv<object, object>(Format.Csv,
+                        lineFilter  : null,
+                        headSelector: delegate { throw new NotImplementedException(); },
+                        rowSelector : delegate { throw new NotImplementedException(); }));
+                Assert.Equal("lineFilter", e.ParamName);
+            }
+
+            [Fact]
+            public void ParseWithNullHeadSelectorThrows()
+            {
+                var e = Assert.Throws<ArgumentNullException>(() =>
+                    new string[0].ParseDsv<object, object>(Format.Csv,
+                        lineFilter  : delegate { throw new NotImplementedException(); },
+                        headSelector: null,
+                        rowSelector : delegate { throw new NotImplementedException(); }));
+                Assert.Equal("headSelector", e.ParamName);
+            }
+
+            [Fact]
+            public void ParseWithNullRowSelectorThrows()
+            {
+                var e = Assert.Throws<ArgumentNullException>(() =>
+                    new string[0].ParseDsv<object, object>(Format.Csv,
+                        lineFilter  : delegate { throw new NotImplementedException(); },
+                        headSelector: delegate { throw new NotImplementedException(); },
+                        rowSelector : null));
+                Assert.Equal("rowSelector", e.ParamName);
+            }
+
+            [Fact]
+            public void ParseIsLazy()
+            {
+                #pragma warning disable 1998 // This async method lacks 'await' operators and will run synchronously
+
+                static async IAsyncEnumerable<string> Lines()
+                {
+                    throw new InvalidOperationException();
+                    #pragma warning disable 162 // Unreachable code detected
+                    yield return null;
+                    #pragma warning restore 162
+                }
+
+                #pragma warning restore 1998
+
+                Lines().ParseDsv<object, object>(
+                    format: Format.Csv,
+                    lineFilter  : delegate { throw new NotImplementedException(); },
+                    headSelector: delegate { throw new NotImplementedException(); },
+                    rowSelector : delegate { throw new NotImplementedException(); });
+            }
+        }
+
+        #endif // ASYNC_ENUM
 
         public class ObservableSource
         {
@@ -226,6 +312,22 @@ namespace Dsv.Tests
                 Type errorType, string errorMessage) =>
             ParseDsv(delimiter, quote, escape, newline, skipBlanks, rows, errorType, errorMessage,
                      lines.ParseDsv);
+
+        #if ASYNC_ENUM
+
+        [Theory]
+        [MemberData(nameof(GetData))]
+        public void
+            ParseDsvWithAsyncEnumerable(
+                char delimiter, char? quote, char escape, string newline, bool skipBlanks,
+                IEnumerable<string> lines, IEnumerable<(int Line, string[] Fields)> rows,
+                Type errorType, string errorMessage) =>
+            ParseDsv(delimiter, quote, escape, newline, skipBlanks, rows, errorType, errorMessage,
+                     (f, rf) => lines.ToAsyncEnumerable()
+                                     .ParseDsv(f, rf)
+                                     .ToEnumerable());
+
+        #endif // ASYNC_ENUM
 
         [Theory]
         [MemberData(nameof(GetData))]


### PR DESCRIPTION
This PR adds support for [async streams](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#async-streams) à la [`IAsyncEnumerable<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.iasyncenumerable-1).