### PR TITLE
Update to use .NET SDK 8.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 image:
-  - Visual Studio 2019
+  - Visual Studio 2022
   - Ubuntu
 skip_commits:
   files:
@@ -13,20 +13,13 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
-- cmd: curl -sSLO https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-win-x64.exe
-- cmd: dotnet-runtime-2.0.9-win-x64.exe /quiet /norestart
-- cmd: curl -sSLO https://download.visualstudio.microsoft.com/download/pr/d046f80d-8ad4-4bb9-8db6-8510105de979/07319c666f9951e15c607aed260ab12d/dotnet-runtime-2.1.13-win-x64.exe
-- cmd: dotnet-runtime-2.1.13-win-x64.exe /quiet /norestart
-- cmd: curl -sSLO https://download.visualstudio.microsoft.com/download/pr/a803822b-178b-4d21-bb7c-aaa1d209c341/e77c5ca1d0ea9963346655e2ec2733f2/dotnet-runtime-2.2.7-win-x64.exe
-- cmd: dotnet-runtime-2.2.7-win-x64.exe /quiet /norestart
-- cmd: curl -sSLO https://download.visualstudio.microsoft.com/download/pr/53f250a1-318f-4350-8bda-3c6e49f40e76/e8cbbd98b08edd6222125268166cfc43/dotnet-sdk-3.0.100-win-x64.exe
-- cmd: dotnet-sdk-3.0.100-win-x64.exe /quiet /norestart
+- ps: if ($isWindows) { Invoke-WebRequest -OutFile dotnet-install.ps1 https://dot.net/v1/dotnet-install.ps1 }
+- ps: if ($isWindows) { ./dotnet-install.ps1 -JSonFile global.json }
+- ps: if ($isWindows) { ./dotnet-install.ps1 -Runtime dotnet -Version 6.0.30 -SkipNonVersionedFiles }
 - sh: curl -sSLO https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
-- sh: ./dotnet-install.sh --version 2.0.9   --runtime dotnet
-- sh: ./dotnet-install.sh --version 2.1.13  --runtime dotnet
-- sh: ./dotnet-install.sh --version 2.2.7   --runtime dotnet
-- sh: ./dotnet-install.sh --version 3.0.100
+- sh: ./dotnet-install.sh --jsonfile global.json
+- sh: ./dotnet-install.sh --runtime dotnet --version 6.0.30 --skip-non-versioned-files
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100"
+    "version": "8.0.300",
+    "rollForward": "latestPatch"
   }
 }

--- a/src/Dsv.csproj
+++ b/src/Dsv.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.4.1</VersionPrefix>
     <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Copyright>Copyright © 2017 Atif Aziz</Copyright>
@@ -33,13 +33,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Interactive.Async">
-      <Version>4.0.0</Version>
+      <Version>6.0.1</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="'$(TargetFramework)'=='netstandard1.0'" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dsv.Tests.csproj
+++ b/tests/Dsv.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -19,17 +19,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
-    <PackageReference Include="morelinq" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Interactive.Async" Version="4.0.0" Condition="'$(TargetFramework)'!='netcoreapp3.0'" />
-    <PackageReference Include="System.Reactive" Version="4.1.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="morelinq" Version="4.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Interactive.Async" Version="6.0.1" Condition="'$(TargetFramework)'!='netcoreapp3.0'" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/ParserTests.cs
+++ b/tests/ParserTests.cs
@@ -256,11 +256,11 @@ namespace Dsv.Tests
 
                 using var cancellationTokenSource = new CancellationTokenSource();
                 var cancellationToken = cancellationTokenSource.Token;
+                CancellationToken capturedCancellationToken = default;
                 await using var e = TestSource(test).ParseCsv().GetAsyncEnumerator(cancellationToken);
 
                 Assert.True(await e.MoveNextAsync());
                 Assert.Equal(test, e.Current[0]);
-                CancellationToken capturedCancellationToken;
                 Assert.Equal(cancellationToken, capturedCancellationToken);
 
                 IAsyncEnumerable<string> TestSource(string test)


### PR DESCRIPTION
This PR updates the solution to use .NET SDK 8 and replaces testing on unsupported runtimes (.NET Core 3.0, 2.1 & 2.2) with latest supported ones (.NET 6 & 8).
