### PR TITLE
Add experimental parsing overloads using readers

### DIFF
--- a/src/Async.cs
+++ b/src/Async.cs
@@ -18,6 +18,7 @@
 
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
@@ -36,6 +37,12 @@ static partial class Parser
                               Func<THead, TextRow, TRow> rowSelector) =>
         lines.ParseDsv(Format.Csv, headSelector, rowSelector);
 
+    [Experimental("DSV001")]
+    public static IAsyncEnumerable<T>
+        ParseCsv<T>(this IAsyncEnumerable<string> lines,
+                    Func<TextRow, Func<TextRow, T>> selector) =>
+        lines.ParseDsv(Format.Csv, selector);
+
     public static IAsyncEnumerable<(T Header, TextRow Row)>
         ParseDsv<T>(this IAsyncEnumerable<string> lines, Format format,
                     Func<TextRow, T> headSelector) =>
@@ -52,6 +59,19 @@ static partial class Parser
                               Func<TextRow, THead> headSelector,
                               Func<THead, TextRow, TRow> rowSelector) =>
         lines.ParseDsv(format, _ => false, headSelector, rowSelector);
+
+    [Experimental("DSV001")]
+    public static IAsyncEnumerable<T>
+        ParseDsv<T>(this IAsyncEnumerable<string> lines, Format format,
+                    Func<TextRow, Func<TextRow, T>> selector) =>
+        lines.ParseDsv(format, _ => false, selector);
+
+    [Experimental("DSV001")]
+    public static IAsyncEnumerable<T>
+        ParseDsv<T>(this IAsyncEnumerable<string> lines, Format format,
+                    Func<string, bool> lineFilter,
+                    Func<TextRow, Func<TextRow, T>> selector) =>
+        lines.ParseDsv(format, lineFilter, selector, (head, row) => head(row));
 
     public static IAsyncEnumerable<TRow>
         ParseDsv<THead, TRow>(this IAsyncEnumerable<string> lines, Format format,

--- a/src/Dsv.csproj
+++ b/src/Dsv.csproj
@@ -41,6 +41,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="'$(TargetFramework)'=='netstandard1.0'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
@@ -49,5 +53,11 @@
     <None Include="..\COPYING.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
     <None Include="..\README.md" Pack="true" PackagePath="$(PackageReadmeFile)" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <PolySharpIncludeGeneratedTypes>
+      System.Diagnostics.CodeAnalysis.ExperimentalAttribute
+    </PolySharpIncludeGeneratedTypes>
+  </PropertyGroup>
 
 </Project>

--- a/src/Parser.cs
+++ b/src/Parser.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Dsv
@@ -65,6 +66,9 @@ namespace Dsv
 #pragma warning restore CA1815 // Override equals and operator equals on value types
     {
         readonly string[]? fields;
+
+        [Experimental("DSV001")]
+        public static readonly Func<TextRow, TextRow> Reader = static row => row;
 
         internal TextRow(int lineNumber, string[] fields)
         {

--- a/src/Rx.cs
+++ b/src/Rx.cs
@@ -15,6 +15,7 @@
 #endregion
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Dsv.Reactive;
 
 namespace Dsv
@@ -30,6 +31,11 @@ namespace Dsv
                                   Func<TextRow, THead> headSelector,
                                   Func<THead, TextRow, TRow> rowSelector) =>
             lines.ParseDsv(Format.Csv, headSelector, rowSelector);
+
+        [Experimental("DSV001")]
+        public static IObservable<T> ParseCsv<T>(this IObservable<string> lines,
+                                                 Func<TextRow, Func<TextRow, T>> selector) =>
+            lines.ParseDsv(Format.Csv, selector);
 
         public static IObservable<(T Header, TextRow Row)>
             ParseDsv<T>(this IObservable<string> lines, Format format,
@@ -47,6 +53,17 @@ namespace Dsv
                                   Func<TextRow, THead> headSelector,
                                   Func<THead, TextRow, TRow> rowSelector) =>
             lines.ParseDsv(format, _ => false, headSelector, rowSelector);
+
+        [Experimental("DSV001")]
+        public static IObservable<T> ParseDsv<T>(this IObservable<string> lines, Format format,
+                                                 Func<TextRow, Func<TextRow, T>> selector) =>
+            lines.ParseDsv(format, _ => false, selector);
+
+        [Experimental("DSV001")]
+        public static IObservable<T> ParseDsv<T>(this IObservable<string> lines, Format format,
+                                                 Func<string, bool> lineFilter,
+                                                 Func<TextRow, Func<TextRow, T>> selector) =>
+            lines.ParseDsv(format, lineFilter, selector, (head, row) => head(row));
 
         public static IObservable<TRow>
             ParseDsv<THead, TRow>(this IObservable<string> lines, Format format,

--- a/src/Seq.cs
+++ b/src/Seq.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Dsv;
 
@@ -30,6 +31,11 @@ static partial class Parser
                               Func<TextRow, THead> headSelector,
                               Func<THead, TextRow, TRow> rowSelector) =>
         lines.ParseDsv(Format.Csv, headSelector, rowSelector);
+
+    [Experimental("DSV001")]
+    public static IEnumerable<T> ParseCsv<T>(this IEnumerable<string> lines,
+                                             Func<TextRow, Func<TextRow, T>> selector) =>
+        lines.ParseDsv(Format.Csv, selector);
 
     public static IEnumerable<(T Header, TextRow Row)>
         ParseDsv<T>(this IEnumerable<string> lines, Format format,
@@ -47,6 +53,19 @@ static partial class Parser
                               Func<TextRow, THead> headSelector,
                               Func<THead, TextRow, TRow> rowSelector) =>
         lines.ParseDsv(format, _ => false, headSelector, rowSelector);
+
+    [Experimental("DSV001")]
+    public static IEnumerable<T> ParseDsv<T>(this IEnumerable<string> lines,
+                                             Format format,
+                                             Func<TextRow, Func<TextRow, T>> selector) =>
+        lines.ParseDsv(format, _ => false, selector);
+
+    [Experimental("DSV001")]
+    public static IEnumerable<T> ParseDsv<T>(this IEnumerable<string> lines,
+                                             Format format,
+                                             Func<string, bool> lineFilter,
+                                             Func<TextRow, Func<TextRow, T>> selector) =>
+        lines.ParseDsv(format, lineFilter, selector, (head, row) => head(row));
 
     public static IEnumerable<TRow>
         ParseDsv<THead, TRow>(this IEnumerable<string> lines, Format format,

--- a/tests/Dsv.Tests.csproj
+++ b/tests/Dsv.Tests.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Finq" Version="1.0.0-alpha-01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="morelinq" Version="4.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
This PR adds new _experimental_ overloads that take a _projector_/_selector_ function typed as `Func<TextRow, Func<TextRow, T>>`, as shown below for sequence of strings:

```c#
[Experimental("DSV001")]
public static IEnumerable<T> ParseDsv<T>(this IEnumerable<string> lines,
                                         Format format,
                                         Func<TextRow, Func<TextRow, T>> selector)
{
    // ...
}
```

Similar overloads have also added for `IAsyncEnumerable<string>` and `IObservable<string>`.

These overloads compress other overloads that require two generic type arguments and two projectors for the head and data row types:

https://github.com/atifaziz/Dsv/blob/39c4e84d629200a1dad4e31ce7c8975872bf8c51/src/Seq.cs#L51-L55

`Func<TextRow, Func<TextRow, T>>` is a factory for a row factory. It receives the header row and returns a factory for data rows. This compression requires only a single generic type argument and a (nested) projection function.

A new identity function has been added to `TextRow` as `Reader`:

```c#
partial class TextRow
{
    public static readonly Func<TextRow, TextRow> Reader = static row => row;
}
```

[Finq] enables such a function to be treated as a reader monad. Ultimately, what this permits is to use LINQ to express the header and row reading a computational expression:

```c#
using Finq;
using Dsv;

var reader =
    from hr in TextRow.Reader
    select new
    {
        Name = hr.GetFirstIndex("Name", StringComparison.OrdinalIgnoreCase),
        Age  = hr.GetFirstIndex("Age", StringComparison.OrdinalIgnoreCase),
        City = hr.GetFirstIndex("City", StringComparison.OrdinalIgnoreCase),
    }
    into hr
    select
        from dr in TextRow.Reader
        select new
        {
            Name = dr[hr.Name],
            Age  = int.Parse(dr[hr.Age], NumberStyles.None, CultureInfo.InvariantCulture),
            City = dr[hr.City]
        };

const string csv = """
    Name,Age,City
    Alice,25,New York
    Bob,30,Los Angeles
    Charlie,35,Chicago
    """;

var result = csv.SplitIntoLines()
                .ParseDsv(Format.Csv, _ => false, reader);
```

[Finq]: https://www.nuget.org/packages/Finq/1.0.0-alpha-01
